### PR TITLE
addressed numpy-financial deprecation, sequence index deprecation

### DIFF
--- a/dependencies.xml
+++ b/dependencies.xml
@@ -1,5 +1,5 @@
 <dependencies>
   <main>
-    <numpy-financial/>
+    <numpy-financial source='forge'/>
   </main>
 </dependencies>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -1,0 +1,5 @@
+<dependencies>
+  <main>
+    <numpy-financial/>
+  </main>
+</dependencies>

--- a/src/main.py
+++ b/src/main.py
@@ -25,6 +25,7 @@ import functools
 from collections import defaultdict, OrderedDict
 
 import numpy as np
+import numpy_financial as npf
 try:
   from TEAL.src import CashFlows
   # NOTE this import exception is ONLY to allow RAVEN to directly import this extmod.
@@ -372,9 +373,10 @@ def projectSingleCashflow(cf, start, end, life, lifeCf, taxMult, inflRate, proje
   # if the last year is a rebuild year, don't rebuild, as it won't be operated.
   if newBuildMask[0][-1] == years[-1]:
     newBuildMask[0] = newBuildMask[0][:-1]
+  ## numpy requires tuples as indices, not lists
+  newBuildMask = tuple(newBuildMask)
   ## add construction costs for all of these new build years
   projCf[newBuildMask] = lifeCf[0] * taxMult * np.power(inflRate, -1*years[newBuildMask])
-  #print(projCf)
   ## this is all the years in which decomissioning happens
   ### note that the [0] index is sort of a dummy dimension to help the numpy handshakes
   ### if last decomission is within project life, include that too
@@ -459,7 +461,7 @@ def NPV(components, cashFlows, projectLength, discountRate, mult=None, v=100, re
   """
   m = 'NPV'
   fcff = FCFF(components, cashFlows, projectLength, mult=mult, v=v)
-  npv = np.npv(discountRate, fcff)
+  npv = npf.npv(discountRate, fcff)
   vprint(v, 0, m, '... NPV: {: 1.9e}'.format(npv))
   if not returnFcff:
     return npv
@@ -479,7 +481,7 @@ def IRR(components, cashFlows, projectLength, v=100):
   fcff = FCFF(components, cashFlows, projectLength, mult=None, v=v) # TODO mult is none always?
   # this method can crash if no solution exists!
   #try:
-  irr = np.irr(fcff)
+  irr = npf.irr(fcff)
   vprint(v, 1, m, '... IRR: {: 1.9e}'.format(irr))
   #except: # TODO what kind of crash? General catching is bad practice.
   #  vprint(v, 99, m, 'IRR search failed! No solution found. Setting IRR to -10 for debugging.')


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
Closes #35 

##### What are the significant changes in functionality due to this change request?
Fixes two deprecation warnings, one by introducing `numpy-financial`, one by changing mapping indices into a tuple.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/HERON/wiki/Code-Standards) for details.
- [x] 4. Automated Tests should pass.
- [x] 5. If significant functionality is added, there must be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large tes.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added, the the analytic documentation must be updated/added.
- [x] 9. If any test used as a basis for documentation examples have been changed, the associated documentation must be reviewed and assured the text matches the example.

