### PR TITLE
Changed handling of recurring cashflows to better suit object oriented

### DIFF
--- a/src/CashFlows.py
+++ b/src/CashFlows.py
@@ -28,9 +28,8 @@ import xml.etree.ElementTree as ET
 
 import numpy as np
 import time
-###
-import itertools as iter
-###
+import itertools as it
+
 from ..src import Amortization
 
 from ravenframework.utils import mathUtils
@@ -1237,13 +1236,12 @@ class Recurring(CashFlow):
                 listArray[i] = value
               listArray[0] = 0
               toExtend[name] = np.array(listArray)
-          # alpha and driver arrays should be the same length as the project life
-          # This conditional considers cases where driver and alpha array have same length as component life
-          # This will happen with xml runs of TEAL
+          # Checking for scenario where alpha or driver do not match project length
+          # There will be
           elif 1 < len(value) < t or len(value) > t:
-            listArray = np.empty(t)
+            listArray = np.zeros(t)
             # cycling through driver/alpha array starting from 1 since recurring cfs are 0 in year 0
-            repeatingValues = iter.cycle(value[1:])
+            repeatingValues = it.cycle(value[1:])
             listArray[1:] = [next(repeatingValues) for _ in listArray[1:]]
             toExtend[name] = listArray
         elif type(value) is str:

--- a/src/CashFlows.py
+++ b/src/CashFlows.py
@@ -1235,6 +1235,24 @@ class Recurring(CashFlow):
                 listArray[i] = value
               listArray[0] = 0
               toExtend[name] = np.array(listArray)
+          # alpha and driver arrays should be the same length as the project length
+          elif len(value) > 1 and len(value) < t or len(value) > t:
+            listArray = np.empty(t)
+            # minus 1 to remove 0 at beginning cf timeline
+            paramLength = len(value) - 1
+            # Starting at one since the first index will always be zero for driver and alpha
+            relativeIndex = 1
+            for i in range(t):
+              # Following the convention for recurring
+              if i == 0:
+                listArray[i] = 0
+                continue
+              listArray[i] = value[relativeIndex]
+              relativeIndex += 1
+              # Checking if it is necessary to start repeating driver/array from beginning
+              if relativeIndex > paramLength:
+                relativeIndex = 1
+            toExtend[name] = listArray
         elif type(value) is str:
           continue
         else:

--- a/src/CashFlows.py
+++ b/src/CashFlows.py
@@ -28,7 +28,9 @@ import xml.etree.ElementTree as ET
 
 import numpy as np
 import time
-
+###
+import itertools as iter
+###
 from ..src import Amortization
 
 from ravenframework.utils import mathUtils
@@ -1235,23 +1237,14 @@ class Recurring(CashFlow):
                 listArray[i] = value
               listArray[0] = 0
               toExtend[name] = np.array(listArray)
-          # alpha and driver arrays should be the same length as the project length
-          elif len(value) > 1 and len(value) < t or len(value) > t:
+          # alpha and driver arrays should be the same length as the project life
+          # This conditional considers cases where driver and alpha array have same length as component life
+          # This will happen with xml runs of TEAL
+          elif 1 < len(value) < t or len(value) > t:
             listArray = np.empty(t)
-            # minus 1 to remove 0 at beginning cf timeline
-            paramLength = len(value) - 1
-            # Starting at one since the first index will always be zero for driver and alpha
-            relativeIndex = 1
-            for i in range(t):
-              # Following the convention for recurring
-              if i == 0:
-                listArray[i] = 0
-                continue
-              listArray[i] = value[relativeIndex]
-              relativeIndex += 1
-              # Checking if it is necessary to start repeating driver/array from beginning
-              if relativeIndex > paramLength:
-                relativeIndex = 1
+            # cycling through driver/alpha array starting from 1 since recurring cfs are 0 in year 0
+            repeatingValues = iter.cycle(value[1:])
+            listArray[1:] = [next(repeatingValues) for _ in listArray[1:]]
             toExtend[name] = listArray
         elif type(value) is str:
           continue

--- a/src/CashFlows.py
+++ b/src/CashFlows.py
@@ -1237,13 +1237,13 @@ class Recurring(CashFlow):
               listArray[0] = 0
               toExtend[name] = np.array(listArray)
           # Checking for scenario where alpha or driver do not match project length
-          # There will be
+          # having mismatched alpha and driver will cause an operand error later in the workflow
           elif 1 < len(value) < t or len(value) > t:
-            listArray = np.zeros(t)
+            correctedCoefs = np.zeros(t)
             # cycling through driver/alpha array starting from 1 since recurring cfs are 0 in year 0
-            repeatingValues = it.cycle(value[1:])
-            listArray[1:] = [next(repeatingValues) for _ in listArray[1:]]
-            toExtend[name] = listArray
+            cycledCoefs = it.cycle(value[1:])
+            correctedCoefs[1:] = [next(cycledCoefs) for _ in correctedCoefs[1:]]
+            toExtend[name] = correctedCoefs
         elif type(value) is str:
           continue
         else:

--- a/src/main.py
+++ b/src/main.py
@@ -380,18 +380,14 @@ def projectRecurringCashflow(cf, start, end, lifeCf, taxMult, inflRate, projectL
   else:
     projCf = np.zeros(projectLength, dtype=object)
   years = np.arange(projectLength) # years in project time, year 0 is first year # TODO just indices, pandas?
-  # before the project starts, after it ends are zero; we want the working part
-  # ALFOA: Modified following expression (see issue #20):
-  #        from operatingMask = np.logical_and(years >= start, years <= end)
-  #        to operatingMask = np.logical_and(years >= start, years < end)
   operatingMask = np.logical_and(years >= start, years < end)
   operatingYears = years[operatingMask]
-  relativeOperatingYears = operatingYears - start # This is relative component startup year
-
-  # Calculating dispatch cashflow for the duration of the project for each year
-  # Handling inflation and tax rates for the project based on how many years into the project
+  # This considers components that dont start operation until later in the project
+  # It is neccessary to index lifeCf from 0 while still indexing projCf and years from current project year
+  relativeStartupYear = operatingYears - start
   for year in range(len(operatingYears)):
-    projCf[operatingYears[year]] = lifeCf[relativeOperatingYears[year]] * taxMult * np.power(inflRate, -1*years[operatingYears[year]])
+    # Necessary to discount the cashflow with tax and inflation, for recurring inflRate is typically 1
+    projCf[operatingYears[year]] = lifeCf[relativeStartupYear[year]] * taxMult * np.power(inflRate, -1*years[operatingYears[year]])
   return projCf
 
 def projectSingleCashflow(cf, start, end, life, lifeCf, taxMult, inflRate, projectLength, v=100, pyomoVar=False):

--- a/tests/HourlyObjectOrientedTest.py
+++ b/tests/HourlyObjectOrientedTest.py
@@ -80,11 +80,11 @@ def build_econ_components(df, settings):
   cfs = []
 
   ### recurring cashflow evaluated hourly, to show usage
-  cf = createRecurringHourly(df, comp, 'A', 'D')
+  cf = createRecurringHourly(df, comp, life, 'A', 'D')
   cfs.append(cf)
   print('DEBUGG hourly recurring:', cf._yearlyCashflow)
   ### recurring cashflow evaluated yearly
-  cf = createRecurringYearly(df, comp, 'A', 'D')
+  cf = createRecurringYearly(df, comp, life, 'A', 'D')
   cfs.append(cf)
   print('DEBUGG yearly recurring:', cf._yearlyCashflow)
   ### capex cashflow
@@ -126,16 +126,16 @@ def createCapex(df, comp, driver, alpha):
   cf.setParams(cfFarams)
   return cf
 
-def createRecurringYearly(df, comp, driver, alpha):
+def createRecurringYearly(df, comp, life, driver, alpha):
   """
     Constructs recurring cashflow with one value per year
     @ In, df, pandas.Dataframe, loaded data to run
     @ In, comp, CashFlow.Component, component this cf will belong to
+    @ In, life, int, length of project in years
     @ In, driver, string, variable name in df to take driver from
     @ In, alpha, string, variable name in df to take alpha from
     @ Out, comps, dict, dict mapping names to CashFlow component objects
   """
-  life = comp.getLifetime()
   cf = CashFlows.Recurring()
   cfFarams = {'name': 'RecursYearly',
                'X': 1,
@@ -152,16 +152,16 @@ def createRecurringYearly(df, comp, driver, alpha):
   cf.computeYearlyCashflow(alphas, drivers)
   return cf
 
-def createRecurringHourly(df, comp, driver, alpha):
+def createRecurringHourly(df, comp, life, driver, alpha):
   """
     Constructs recurring cashflow with one value per hour
     @ In, df, pandas.Dataframe, loaded data to run
     @ In, comp, CashFlow.Component, component this cf will belong to
     @ In, driver, string, variable name in df to take driver from
+    @ In, life, int, length of project in years
     @ In, alpha, string, variable name in df to take alpha from
     @ Out, comps, dict, dict mapping names to CashFlow component objects
   """
-  life = comp.getLifetime()
   cf = CashFlows.Recurring()
   cfFarams = {'name': 'RecursHourly',
                'X': 1,
@@ -196,9 +196,7 @@ if __name__ == '__main__':
   datetime = years + hours
   df.index = datetime
   df = df.sort_index()[['A', 'B', 'C', 'D']]
-
   metrics = run(df)
-
   calculated = metrics['NPV']
   correct = 2.213218922e+08
   # NOTE if inflation is applied to all cashflows, answer is 2.080898547e+08


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
#58 

##### What are the significant changes in functionality due to this change request?
When defining cashflows outside of TEAL, calculateYearlyCashflow/calculateIntraYearlyCashflow over the project lifetimes. TEAL will now consider a unique cashflow expression for each year of the project life.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/HERON/wiki/Code-Standards) for details.
- [x] 4. Automated Tests should pass.
- [x] 5. If significant functionality is added, there must be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large tes.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added, the the analytic documentation must be updated/added.
- [x] 9. If any test used as a basis for documentation examples have been changed, the associated documentation must be reviewed and assured the text matches the example.

