### PR TITLE
Depreciation cashflows now included in NPV Search as necessary

### DIFF
--- a/src/CashFlows.py
+++ b/src/CashFlows.py
@@ -579,6 +579,7 @@ class Component:
       return []
     scheme, plan = amort
     alpha = Amortization.amortize(scheme, plan, 1.0, self._lifetime)
+    is_mult_target = ocf.isMultTarget() # if original CAPEX is mult target, these should be also
     # first cash flow is POSITIVE on the balance sheet, is not taxed, and is a percent of the target
     # -> this is the tax credit from MACRS for component value loss
     pos = Amortizor(credit=True, component=self.name, verbosity=self._verbosity, pos=True)
@@ -587,6 +588,7 @@ class Component:
               'tax': False,
               'inflation': 'real',
               'alpha': alpha,
+              'mult_target': is_mult_target, #this is dependent on CAPEX price, should be included
               'reference': 1.0,
               'X': 1.0,
               }
@@ -601,6 +603,7 @@ class Component:
               'tax': True,
               'inflation': 'real',
               'alpha': nalpha,
+              'mult_target': is_mult_target, #this is dependent on CAPEX price, should be included
               'reference': 1.0,
               'X': 1.0}
     neg.setParams(params)


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
#73 

##### What are the significant changes in functionality due to this change request?
Amortization cashflows, if created, will carry a `mult_target` parameter that matches the original cash flow's `mult_target`. That way, if `True`, the depreciation cashflows will also be included in the multiplication terms within NPV Search. 

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/HERON/wiki/Code-Standards) for details.
- [x] 4. Automated Tests should pass.
- [x] 5. If significant functionality is added, there must be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large tes.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added, the the analytic documentation must be updated/added.
- [x] 9. If any test used as a basis for documentation examples have been changed, the associated documentation must be reviewed and assured the text matches the example.

